### PR TITLE
Add EC Theory Arbitrage link pages

### DIFF
--- a/_posts/2025-07-07-fa.md
+++ b/_posts/2025-07-07-fa.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: "EC Theory Arbitrage invite list"
+redirect_to: https://docs.google.com/spreadsheets/d/1RwUz-FfzeiwTnev40-YCAc0NxjslAECYM1-HydUwNt8
+---

--- a/_posts/2025-07-07-fb.md
+++ b/_posts/2025-07-07-fb.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: "EC Theory Arbitrage overleaf"
+redirect_to: https://www.overleaf.com/read/hnzkvrzkfswg#cb0672
+---


### PR DESCRIPTION
## Summary
- add new post linking to EC Theory Arbitrage invite list
- add new post linking to EC Theory Arbitrage Overleaf document

## Testing
- `bundle exec jekyll build` *(fails: command not found)*
- `bundle install` *(fails: bundler error)*

------
https://chatgpt.com/codex/tasks/task_e_686c4a48e4a48322b49ad15a21c6f813