### PR TITLE
Add evo-epi meeting slides redirect post

### DIFF
--- a/_posts/2026-02-27-gf.md
+++ b/_posts/2026-02-27-gf.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: "evo-epi meeting slides"
+redirect_to: https://docs.google.com/presentation/d/1Xra3mqWQlh9hlIp53BgOXxH1V8vcVTwzPxE0xvj0w6Y
+---


### PR DESCRIPTION
## Summary
Added a new blog post that redirects to the evo-epi meeting slides presentation.

## Changes
- Created new post file `_posts/2026-02-27-gf.md` with a redirect to the Google Slides presentation
- The post uses Jekyll's redirect_to front matter to automatically forward users to the presentation URL

## Details
This is a simple redirect post that points to an external Google Slides presentation for the evo-epi meeting. When accessed, it will redirect visitors to the full presentation at the specified Google Docs URL.

https://claude.ai/code/session_01HiaUnJXNGAFw1xV4V18MYW