### PR TITLE
Add redirect post for sync-up meeting slides

### DIFF
--- a/_posts/2026-03-23-gh.md
+++ b/_posts/2026-03-23-gh.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: "Sync-up Meeting Slides"
+redirect_to: https://docs.google.com/presentation/d/1C190aUIm_e3sSdXqNjo2g3JipVEB-tU3caH53MOmPrs
+---


### PR DESCRIPTION
## Summary
Added a new blog post that redirects to the sync-up meeting slides presentation.

## Changes
- Created a new post (`_posts/2026-03-23-gh.md`) that serves as a redirect to the Google Slides presentation for the sync-up meeting
- The post uses Jekyll's `redirect_to` front matter to automatically redirect visitors to the external presentation URL

## Details
This is a simple redirect post that allows the meeting slides to be referenced from the blog while hosting the actual presentation on Google Slides. When accessed, visitors will be automatically redirected to the presentation at `https://docs.google.com/presentation/d/1C190aUIm_e3sSdXqNjo2g3JipVEB-tU3caH53MOmPrs`.

https://claude.ai/code/session_01F9jTehPjMVg7MjdPhWNgyH