### PR TITLE
Add EXPRESS project documentation redirect posts

### DIFF
--- a/_posts/2026-04-27-gk.md
+++ b/_posts/2026-04-27-gk.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: "EXPRESS Progress Report"
+redirect_to: https://docs.google.com/document/d/1cQuVhns6Tzee1yn0BkcZvqegMF2hgRfT0YlUcNXpvcY
+---

--- a/_posts/2026-04-27-gl.md
+++ b/_posts/2026-04-27-gl.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: "EXPRESS NCE Request"
+redirect_to: https://docs.google.com/document/d/1-l-BPPW-VXvJXmPLexrobg6VEc6owHJBEwHwNxRrDNM
+---


### PR DESCRIPTION
## Summary
Added two new blog post files that serve as redirects to external Google Docs documents for EXPRESS project documentation.

## Key Changes
- Added `_posts/2026-04-27-gk.md`: Redirect post for EXPRESS Progress Report
- Added `_posts/2026-04-27-gl.md`: Redirect post for EXPRESS NCE Request

## Implementation Details
Both posts use the Jekyll redirect layout to forward users to their respective Google Docs:
- Progress Report: https://docs.google.com/document/d/1cQuVhns6Tzee1yn0BkcZvqegMF2hgRfT0YlUcNXpvcY
- NCE Request: https://docs.google.com/document/d/1-l-BPPW-VXvJXmPLexrobg6VEc6owHJBEwHwNxRrDNM

This approach allows the documentation to be maintained in Google Docs while being discoverable through the blog's post listing.

https://claude.ai/code/session_01Cc3EeiJnSMFKKuCSK53s6r