### PR TITLE
Add evo-epi meeting slides redirect for June 1, 2026

### DIFF
--- a/_posts/2026-05-08-gn.md
+++ b/_posts/2026-05-08-gn.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: "evo-epi meeting slides June 1, 2026"
+redirect_to: https://docs.google.com/presentation/d/1HNiQCsbAkvl-jv4dk8ahdfAe_ae9hPp_OfTyDjrdT7I
+---


### PR DESCRIPTION
## Summary
Added a new blog post that redirects to the evo-epi meeting slides presentation scheduled for June 1, 2026.

## Changes
- Created new post file `_posts/2026-05-08-gn.md` with a redirect to the Google Slides presentation
- The post uses Jekyll's redirect_to front matter to point to the shared presentation link

## Details
This is a redirect post that will serve as an archive entry while directing visitors to the actual presentation hosted on Google Slides. The post is dated May 8, 2026, ahead of the June 1 meeting date.

https://claude.ai/code/session_018vVCTDHcZKEzZ7cQqoLcbi