### PR TITLE
Add allele evo/epi visual abstract redirect post

### DIFF
--- a/_posts/2026-06-01-gr.md
+++ b/_posts/2026-06-01-gr.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: "allele evo/epi visual abstract"
+redirect_to: https://docs.google.com/presentation/d/1tVDMgbQpQGm6rKBoUJRY7bOBq-fVbgpNrgye6JojjIU
+---


### PR DESCRIPTION
## Summary
Added a new blog post that redirects to an external Google Slides presentation about allele evolution and epigenetics visual abstract.

## Changes
- Created new post file `_posts/2026-06-01-gr.md` with a redirect to a Google Slides presentation
- Post uses Jekyll's redirect_to front matter to automatically forward visitors to the external resource at `https://docs.google.com/presentation/d/1tVDMgbQpQGm6rKBoUJRY7bOBq-fVbgpNrgye6JojjIU`

## Details
This is a simple redirect post that allows the blog to maintain a URL for the allele evolution/epigenetics visual abstract while hosting the actual content on Google Slides.

https://claude.ai/code/session_01Gacc5q3PTWpHo2HdSChfaL