### PR TITLE
Add GPTP 2026 slides redirect post

### DIFF
--- a/_posts/2026-06-03-gs.md
+++ b/_posts/2026-06-03-gs.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: "GPTP 2026 Slides"
+redirect_to: https://docs.google.com/presentation/d/1F52FAVBvby-4FBE9Q4lozKZFTru6PWQaW3doEr387QM
+---


### PR DESCRIPTION
## Summary
Added a new blog post that redirects to the GPTP 2026 presentation slides.

## Changes
- Created new post file `_posts/2026-06-03-gs.md` with a redirect to the Google Slides presentation for GPTP 2026
- The post uses Jekyll's redirect_to front matter to automatically forward visitors to the external slides URL

## Details
This is a simple redirect post that allows the blog to serve as a landing page for the GPTP 2026 slides while maintaining the presentation in Google Slides for easier collaboration and editing.

https://claude.ai/code/session_01QpUqpBquwUyfDc83BsVEMZ