### PR TITLE
Add welcome LOI redirect post

### DIFF
--- a/_posts/2026-07-04-gv.md
+++ b/_posts/2026-07-04-gv.md
@@ -1,5 +1,5 @@
 ---
 layout: post
-title: "welcome LOI"
+title: "welcomme LOI"
 redirect_to: https://docs.google.com/document/d/11ujwRMHa4y24Pap-gz1hfHsoOMY9P26C
 ---

--- a/_posts/2026-07-04-gv.md
+++ b/_posts/2026-07-04-gv.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: "welcome LOI"
+redirect_to: https://docs.google.com/document/d/11ujwRMHa4y24Pap-gz1hfHsoOMY9P26C
+---


### PR DESCRIPTION
## Summary
Added a new blog post that redirects to an external Google Docs document containing the welcome Letter of Intent (LOI).

## Changes
- Created new post file `_posts/2026-07-04-gv.md` with redirect functionality
- Configured the post to redirect to the Google Docs LOI document at `https://docs.google.com/document/d/11ujwRMHa4y24Pap-gz1hfHsoOMY9P26C`

## Implementation Details
The post uses Jekyll's redirect_to front matter to automatically redirect visitors to the external Google Docs link, allowing the LOI to be referenced through the blog while maintaining the document in Google Docs.

https://claude.ai/code/session_01UdT6zafBM6775W2xaEqJmv