### PR TITLE
Add redirect post for Wellcome Leap resistance networks LOI

### DIFF
--- a/_posts/2026-07-21-gy.md
+++ b/_posts/2026-07-21-gy.md
@@ -1,0 +1,5 @@
+---
+layout: post
+title: "wellcome leap resistance networks LOI budget"
+redirect_to: https://docs.google.com/spreadsheets/d/1hfl2VEHLXTr-MYeuSYIDIxDUSQ8vL_cSq40yckdcUDg
+---


### PR DESCRIPTION
## Summary
Added a new blog post that redirects to an external Google Sheets document containing budget information for the Wellcome Leap resistance networks Letter of Intent (LOI).

## Changes
- Created new post file `_posts/2026-07-21-gy.md` that serves as a redirect to the Wellcome Leap resistance networks LOI budget spreadsheet
- Post uses Jekyll's redirect_to front matter to forward users to the external Google Sheets document

## Details
This is a redirect post that allows the blog to maintain a URL for this content while hosting the actual budget information in a shared Google Sheets document. The post is dated 2026-07-21 and will appear in the blog's post listing while seamlessly redirecting visitors to the external resource.

https://claude.ai/code/session_01Y5F1HRgGnAHNoFK3x3JYzg